### PR TITLE
Add file drag and drop

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "printWidth": 80,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@types/node": "18.15.3",
         "@types/react": "18.0.28",
         "@types/react-dom": "18.0.11",
+        "clsx": "^1.2.1",
         "eslint": "8.36.0",
         "eslint-config-next": "13.2.4",
         "multer": "^1.4.5-lts.1",
@@ -1067,6 +1068,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "18.15.3",
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.11",
+    "clsx": "^1.2.1",
     "eslint": "8.36.0",
     "eslint-config-next": "13.2.4",
     "multer": "^1.4.5-lts.1",

--- a/src/components/Dropzone.tsx
+++ b/src/components/Dropzone.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+'use client';
+
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 interface DropZoneProps {
   onDragStateChange?: (isDragActive: boolean) => void;
@@ -10,7 +12,7 @@ interface DropZoneProps {
   className?: string;
 }
 
-export default function DropZone({
+export default function Dropzone({
   onDragStateChange,
   onFilesDrop,
   onDrag,

--- a/src/components/Dropzone.tsx
+++ b/src/components/Dropzone.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface DropZoneProps {
+  onDragStateChange?: (isDragActive: boolean) => void;
+  onDrag?: () => void;
+  onDragIn?: () => void;
+  onDragOut?: () => void;
+  onDrop?: () => void;
+  onFilesDrop?: (files: File[]) => void;
+  className?: string;
+}
+
+export default function DropZone({
+  onDragStateChange,
+  onFilesDrop,
+  onDrag,
+  onDragIn,
+  onDragOut,
+  onDrop,
+  className,
+  children,
+}: React.PropsWithChildren<DropZoneProps>) {
+  // Create state to keep track when dropzone is active/non-active:
+  const [isDragActive, setIsDragActive] = useState(false);
+  // Prepare ref for dropzone element:
+  const dropZoneRef = useRef<null | HTMLDivElement>(null);
+
+  // Create helper method to map file list to array of files:
+  const mapFileListToArray = (files: FileList) => {
+    const array = [];
+
+    for (let i = 0; i < files.length; i++) {
+      array.push(files.item(i));
+    }
+
+    return array;
+  };
+
+  // Create handler for dragenter event:
+  const handleDragIn = useCallback(
+    (event: DragEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onDragIn?.();
+
+      if (event.dataTransfer?.items && event.dataTransfer.items.length > 0) {
+        setIsDragActive(true);
+      }
+    },
+    [onDragIn],
+  );
+
+  // Create handler for dragleave event:
+  const handleDragOut = useCallback(
+    (event: DragEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onDragOut?.();
+
+      setIsDragActive(false);
+    },
+    [onDragOut],
+  );
+
+  // Create handler for dragover event:
+  const handleDrag = useCallback(
+    (event: DragEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      onDrag?.();
+      if (!isDragActive) {
+        setIsDragActive(true);
+      }
+    },
+    [isDragActive, onDrag],
+  );
+
+  // Create handler for drop event:
+  const handleDrop = useCallback(
+    (event: DragEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      setIsDragActive(false);
+      onDrop?.();
+
+      if (event.dataTransfer?.files && event.dataTransfer.files.length > 0) {
+        const files = mapFileListToArray(event.dataTransfer.files) as File[];
+
+        onFilesDrop?.(files);
+        event.dataTransfer.clearData();
+      }
+    },
+    [onDrop, onFilesDrop],
+  );
+
+  // Obser active state and emit changes:
+  useEffect(() => {
+    onDragStateChange?.(isDragActive);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDragActive]);
+
+  // Attach listeners to dropzone on mount:
+  useEffect(() => {
+    const tempZoneRef = dropZoneRef?.current;
+    if (tempZoneRef) {
+      tempZoneRef.addEventListener('dragenter', handleDragIn);
+      tempZoneRef.addEventListener('dragleave', handleDragOut);
+      tempZoneRef.addEventListener('dragover', handleDrag);
+      tempZoneRef.addEventListener('drop', handleDrop);
+    }
+
+    // Remove listeners from dropzone on unmount:
+    return () => {
+      tempZoneRef?.removeEventListener('dragenter', handleDragIn);
+      tempZoneRef?.removeEventListener('dragleave', handleDragOut);
+      tempZoneRef?.removeEventListener('dragover', handleDrag);
+      tempZoneRef?.removeEventListener('drop', handleDrop);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Render <div /> with ref and children:
+  return (
+    <div ref={dropZoneRef} className={className}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,9 +1,19 @@
 'use client';
 
 import React, { useState } from 'react';
+import DropZone from './Dropzone';
 
 export default function FileUploadForm() {
   const [file, setFile] = useState<File | null>(null);
+  const [isDropActive, setIsDropActive] = React.useState(false);
+
+  const onDragStateChange = React.useCallback((dragActive: boolean) => {
+    setIsDropActive(dragActive);
+  }, []);
+
+  const onFilesDrop = React.useCallback((files: File[]) => {
+    if (files && files.length > 0) setFile(files[0]);
+  }, []);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files.length > 0)
@@ -37,7 +47,11 @@ export default function FileUploadForm() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <div className="relative w-full h-48 mb-4">
+      <DropZone
+        onDragStateChange={onDragStateChange}
+        onFilesDrop={onFilesDrop}
+        className={'relative w-full h-48 mb-4'}
+      >
         <input
           type="file"
           id="fileUpload"
@@ -68,7 +82,7 @@ export default function FileUploadForm() {
             </div>
           )}
         </label>
-      </div>
+      </DropZone>
       <button
         type="submit"
         className="px-4 py-2 font-bold text-white bg-blue-500 rounded hover:bg-blue-700 focus:ring-2 focus:ring-blue-400"

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -6,8 +6,8 @@ export default function FileUploadForm() {
   const [file, setFile] = useState<File | null>(null);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedFile = event.target.files?.[0];
-    setFile(selectedFile || null);
+    if (event.target.files && event.target.files.length > 0)
+      setFile(event.target.files[0]);
   };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -37,23 +37,41 @@ export default function FileUploadForm() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <div className="mb-4">
-        <label
-          htmlFor="file-upload"
-          className="block mb-2 font-bold text-gray-700"
-        >
-          Select a file to upload:
-        </label>
+      <div className="relative w-full h-48 mb-4">
         <input
           type="file"
-          id="file-upload"
-          className="px-3 py-2 border rounded"
+          id="fileUpload"
+          className="absolute top-0 left-0 invisible w-full h-full"
           onChange={handleFileChange}
+          accept="application/pdf"
         />
+        <label
+          htmlFor="fileUpload"
+          className="flex items-center justify-center h-full p-4 mb-2 font-semibold text-gray-700 bg-gray-100 border-2 border-gray-300 border-dashed cursor-pointer rounded-xl"
+        >
+          {file && file.name ? (
+            <div>
+              {file.name}
+              <br />
+              <span className="text-blue-500 hover:text-blue-700">
+                Change PDF
+              </span>
+            </div>
+          ) : (
+            <div>
+              Drag and drop a PDF here, or
+              <br />
+              <span className="text-blue-500 hover:text-blue-700">
+                browse your device
+              </span>
+              .
+            </div>
+          )}
+        </label>
       </div>
       <button
         type="submit"
-        className="px-4 py-2 font-bold text-white bg-blue-500 rounded hover:bg-blue-700"
+        className="px-4 py-2 font-bold text-white bg-blue-500 rounded hover:bg-blue-700 focus:ring-2 focus:ring-blue-400"
       >
         Submit
       </button>

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,17 +1,18 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useState, useCallback } from 'react';
 import DropZone from './Dropzone';
+import clsx from 'clsx';
 
 export default function FileUploadForm() {
   const [file, setFile] = useState<File | null>(null);
-  const [isDropActive, setIsDropActive] = React.useState(false);
+  const [isDropActive, setIsDropActive] = useState(false);
 
-  const onDragStateChange = React.useCallback((dragActive: boolean) => {
+  const onDragStateChange = useCallback((dragActive: boolean) => {
     setIsDropActive(dragActive);
   }, []);
 
-  const onFilesDrop = React.useCallback((files: File[]) => {
+  const onFilesDrop = useCallback((files: File[]) => {
     if (files && files.length > 0) setFile(files[0]);
   }, []);
 
@@ -50,7 +51,13 @@ export default function FileUploadForm() {
       <DropZone
         onDragStateChange={onDragStateChange}
         onFilesDrop={onFilesDrop}
-        className={'relative w-full h-48 mb-4'}
+        className={clsx(
+          'relative w-full h-48 mb-4',
+          'border-2 border-dashed rounded-xl',
+          isDropActive
+            ? 'bg-blue-200 border-blue-500'
+            : 'bg-gray-100 border-gray-300',
+        )}
       >
         <input
           type="file"
@@ -61,7 +68,7 @@ export default function FileUploadForm() {
         />
         <label
           htmlFor="fileUpload"
-          className="flex items-center justify-center h-full p-4 mb-2 font-semibold text-gray-700 bg-gray-100 border-2 border-gray-300 border-dashed cursor-pointer rounded-xl"
+          className="flex items-center justify-center w-full h-full p-4 mb-2 font-semibold text-gray-700 cursor-pointer"
         >
           {file && file.name ? (
             <div>

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import React, { useState } from "react";
+import React, { useState } from 'react';
 
-const FileUploadForm: React.FC = () => {
+export default function FileUploadForm() {
   const [file, setFile] = useState<File | null>(null);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -16,10 +16,10 @@ const FileUploadForm: React.FC = () => {
 
     try {
       const formData = new FormData();
-      formData.append("pdf", file);
+      formData.append('pdf', file);
 
-      const response = await fetch("/api/upload-pdf", {
-        method: "POST",
+      const response = await fetch('/api/upload-pdf', {
+        method: 'POST',
         body: formData,
       });
 
@@ -28,10 +28,10 @@ const FileUploadForm: React.FC = () => {
       }
 
       const data = await response.json();
-      console.log("File uploaded:", data.fileName);
-      console.log("Extracted text:", data.text);
+      console.log('File uploaded:', data.fileName);
+      console.log('Extracted text:', data.text);
     } catch (error) {
-      console.error("Error uploading file:", error);
+      console.error('Error uploading file:', error);
     }
   };
 
@@ -40,25 +40,23 @@ const FileUploadForm: React.FC = () => {
       <div className="mb-4">
         <label
           htmlFor="file-upload"
-          className="block text-gray-700 font-bold mb-2"
+          className="block mb-2 font-bold text-gray-700"
         >
           Select a file to upload:
         </label>
         <input
           type="file"
           id="file-upload"
-          className="border rounded py-2 px-3"
+          className="px-3 py-2 border rounded"
           onChange={handleFileChange}
         />
       </div>
       <button
         type="submit"
-        className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+        className="px-4 py-2 font-bold text-white bg-blue-500 rounded hover:bg-blue-700"
       >
         Submit
       </button>
     </form>
   );
-};
-
-export default FileUploadForm;
+}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,13 +1,13 @@
-import { Html, Head, Main, NextScript } from 'next/document'
+import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
     <Html lang="en">
       <Head />
-      <body>
+      <body className="text-gray-900 bg-slate-600">
         <Main />
         <NextScript />
       </body>
     </Html>
-  )
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,8 @@
-import Head from "next/head";
-import { Inter } from "next/font/google";
-import FileUploadForm from "@/components/FileUpload";
+import Head from 'next/head';
+import { Inter } from 'next/font/google';
+import FileUploadForm from '@/components/FileUpload';
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({ subsets: ['latin'] });
 
 export default function Home() {
   return (
@@ -14,17 +14,9 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main>
-        <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
-          <div className="divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow">
-            <div className="px-4 py-5 sm:px-6">
-              <h3 className="text-lg leading-6 font-medium text-gray-900">
-                Upload a PDF
-              </h3>
-            </div>
-            <div className="px-4 py-5 sm:p-6">
-              <FileUploadForm />
-            </div>
-          </div>
+        <div className="max-w-lg p-6 mx-4 my-10 text-center bg-white rounded-lg shadow-2xl sm:p-8 sm:mx-auto">
+          <h3 className="mb-4 text-lg font-bold leading-6">Upload a PDF</h3>
+          <FileUploadForm />
         </div>
       </main>
     </>


### PR DESCRIPTION
## Description
This branch updated the styling of the file upload page and added the ability to drop files onto a dropzone.

- Updated styling
- Added the `clsx` package
- Added ability to drop files on dropzone
- Added prettier config

## Testing

- [x] Pull down branch and run `npm install && npm run dev`
- [x] Open `localhost:3000`
- [x] Drag a file from your file explorer into the dropzone and submit the form
- [x] Refresh page
- [x] Click "browse your device", select a file, and submit the form

## Other notes

-  I wanted to implement a vanilla dropzone, so I followed this tutorial: [https://blog.alexdevero.com/react-file-dropzone/](https://blog.alexdevero.com/react-file-dropzone/).
- I added the `clsx` package because it makes constructing classes (especially conditional classes) easier and looks cleaner. I don't mind removing it if you'd prefer keeping the package list down to the bare minimum.
