### PR TITLE
Add schema context

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -132,14 +132,17 @@ export default function FileUploadForm() {
           [property.title]: {
             description: property.description,
             type: property.type,
-            items: property.items.reduce((xcc, item) => ({
-              ...xcc,
-              [item.title]: {
-                description: item.description,
-                type: item.type,
-                example: item.example,
-              },
-            })),
+            items: property.items.reduce(
+              (xcc, item) => ({
+                ...xcc,
+                [item.title]: {
+                  description: item.description,
+                  type: item.type,
+                  example: item.example,
+                },
+              }),
+              {},
+            ),
           },
         };
       } else {

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import DropZone from './Dropzone';
 import clsx from 'clsx';
 import RawJsonDisplay from './RawJsonDisplay';
@@ -10,8 +10,9 @@ import { AiOutlinePlus, AiOutlineClose } from 'react-icons/ai'; // Import the ne
 
 import { Schema } from '@Types/schemaTypes';
 import SchemaPropertyInput, {
-  SchemaPropertyWithTitle,
+  StatefulSchemaPropertyWithTitle,
 } from './SchemaPropertyInput';
+import SchemaContext from '@Context/schema-context';
 
 export default function FileUploadForm() {
   const [files, setFiles] = useState<File[]>([]);
@@ -34,7 +35,7 @@ export default function FileUploadForm() {
   };
 
   const [schemaProperties, setSchemaProperties] = useState<
-    SchemaPropertyWithTitle[]
+    StatefulSchemaPropertyWithTitle[]
   >([
     {
       title: '',
@@ -44,51 +45,115 @@ export default function FileUploadForm() {
     },
   ]);
 
-  const handleAddSchemaProperty = () => {
-    if (schemaProperties.length < 10) {
-      setSchemaProperties([
-        ...schemaProperties,
-        {
-          title: '',
-          description: '',
-          type: 'string',
-          example: '',
-        },
-      ]);
-    }
-  };
+  const memoizedSchemaContext = useMemo(
+    () => ({
+      schemaProperties,
+      handleAddSchemaProperty: (parentIndex?: number) => {
+        if (parentIndex !== undefined) {
+          const parentProperty = schemaProperties[parentIndex];
+          const updatedSubProperties = parentProperty.items || [];
+          updatedSubProperties?.push({
+            title: '',
+            description: '',
+            type: 'string',
+            example: '',
+          });
 
-  const handleRemoveSchemaProperty = (index: number) => {
-    const updatedSchemaProperties = [...schemaProperties];
-    updatedSchemaProperties.splice(index, 1);
-    setSchemaProperties(updatedSchemaProperties);
-  };
+          parentProperty.items = updatedSubProperties;
 
-  const handleSchemaPropertyChange = (
-    index: number,
-    property: SchemaPropertyWithTitle,
-  ) => {
-    const updatedSchemaProperties = [...schemaProperties];
-    updatedSchemaProperties[index] = property;
-    setSchemaProperties(updatedSchemaProperties);
-  };
+          const updatedSchemaProperties = [...schemaProperties];
+          updatedSchemaProperties[parentIndex] = parentProperty;
+          setSchemaProperties(updatedSchemaProperties);
+        } else {
+          if (schemaProperties.length < 10) {
+            setSchemaProperties([
+              ...schemaProperties,
+              {
+                title: '',
+                description: '',
+                type: 'string',
+                example: '',
+              },
+            ]);
+          }
+        }
+      },
+      handleRemoveSchemaProperty: (index: number, parentIndex?: number) => {
+        if (parentIndex !== undefined) {
+          const parentProperty = schemaProperties[parentIndex];
+          const updatedSubProperties = parentProperty.items || [];
+          updatedSubProperties.splice(index, 1);
+
+          parentProperty.items = updatedSubProperties;
+
+          const updatedSchemaProperties = [...schemaProperties];
+          updatedSchemaProperties[parentIndex] = parentProperty;
+          setSchemaProperties(updatedSchemaProperties);
+        } else {
+          const updatedSchemaProperties = [...schemaProperties];
+          updatedSchemaProperties.splice(index, 1);
+          setSchemaProperties(updatedSchemaProperties);
+        }
+      },
+      handleSchemaPropertyChange: (
+        index: number,
+        property: StatefulSchemaPropertyWithTitle,
+        parentIndex?: number,
+      ) => {
+        if (parentIndex !== undefined) {
+          const parentProperty = schemaProperties[parentIndex];
+          const updatedSubProperties = parentProperty.items || [];
+          updatedSubProperties[index] = property;
+
+          parentProperty.items = updatedSubProperties;
+
+          const updatedSchemaProperties = [...schemaProperties];
+          updatedSchemaProperties[parentIndex] = parentProperty;
+          setSchemaProperties(updatedSchemaProperties);
+        } else {
+          const updatedSchemaProperties = [...schemaProperties];
+          updatedSchemaProperties[index] = property;
+          setSchemaProperties(updatedSchemaProperties);
+        }
+      },
+    }),
+    [schemaProperties],
+  );
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!files.length) return;
 
     // Create schema object from schemaProperties array
-    const schema: Schema = schemaProperties.reduce(
-      (acc, property) => ({
-        ...acc,
-        [property.title]: {
-          description: property.description,
-          type: property.type,
-          example: property.example,
-        },
-      }),
-      {},
-    );
+    const schema: Schema = schemaProperties.reduce((acc, property) => {
+      if (property.items !== undefined) {
+        return {
+          ...acc,
+          [property.title]: {
+            description: property.description,
+            type: property.type,
+            example: property.example,
+            items: property.items.reduce((xcc, item) => ({
+              ...xcc,
+              [item.title]: {
+                description: property.description,
+                type: property.type,
+                example: property.example,
+              },
+            })),
+          },
+        };
+      } else {
+        return {
+          ...acc,
+          [property.title]: {
+            description: property.description,
+            type: property.type,
+            example: property.example,
+          },
+        };
+      }
+    }, {});
 
     setRawJson([]);
     setIsLoading(true);
@@ -131,7 +196,7 @@ export default function FileUploadForm() {
   };
 
   return (
-    <>
+    <SchemaContext.Provider value={memoizedSchemaContext}>
       <form onSubmit={handleSubmit} className="flex flex-wrap items-start">
         <div className="w-full p-1 lg:w-3/5">
           <div className="p-6 bg-white rounded-lg shadow-md">
@@ -142,13 +207,14 @@ export default function FileUploadForm() {
                   <SchemaPropertyInput
                     index={index}
                     property={property}
-                    onChange={handleSchemaPropertyChange}
                     className="p-3 pb-4 mb-2 bg-gray-100 rounded-lg"
                   />
                   {schemaProperties.length > 1 && (
                     <button
                       type="button"
-                      onClick={() => handleRemoveSchemaProperty(index)}
+                      onClick={() =>
+                        memoizedSchemaContext.handleRemoveSchemaProperty(index)
+                      }
                       className="absolute top-0 right-0 p-1 text-red-500 hover:text-red-700"
                     >
                       <AiOutlineClose size={24} />
@@ -159,8 +225,10 @@ export default function FileUploadForm() {
               {schemaProperties.length < 10 && (
                 <button
                   type="button"
-                  onClick={handleAddSchemaProperty}
                   className="flex items-center px-4 py-2 mt-2 font-bold text-white bg-green-500 rounded hover:bg-green-700 focus:ring-2 focus:ring-green-400"
+                  onClick={() =>
+                    memoizedSchemaContext.handleAddSchemaProperty()
+                  }
                 >
                   <AiOutlinePlus size={24} className="mx-2" /> Add Field
                 </button>
@@ -243,6 +311,6 @@ export default function FileUploadForm() {
           </div>
         </div>
       </form>
-    </>
+    </SchemaContext.Provider>
   );
 }

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -132,13 +132,12 @@ export default function FileUploadForm() {
           [property.title]: {
             description: property.description,
             type: property.type,
-            example: property.example,
             items: property.items.reduce((xcc, item) => ({
               ...xcc,
               [item.title]: {
-                description: property.description,
-                type: property.type,
-                example: property.example,
+                description: item.description,
+                type: item.type,
+                example: item.example,
               },
             })),
           },
@@ -154,6 +153,8 @@ export default function FileUploadForm() {
         };
       }
     }, {});
+
+    console.log(schema);
 
     setRawJson([]);
     setIsLoading(true);

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -190,16 +190,17 @@ export default function FileUploadForm() {
                 accept="application/pdf"
                 multiple
               />
+
               <label
                 htmlFor="fileUpload"
-                className="flex items-center justify-center w-full h-full p-4 mb-2 font-semibold text-gray-700 cursor-pointer"
+                className="flex items-center justify-center w-full h-full p-4 mb-2 font-semibold text-center text-gray-700 cursor-pointer"
               >
                 {files.length ? (
                   <div>
-                    {files.length} file(s) selected
+                    {files.length} file&#40;s&#41; selected
                     <br />
                     <span className="text-blue-500 hover:text-blue-700">
-                      Change PDF(s)
+                      Change PDF&#40;s&#41;
                     </span>
                   </div>
                 ) : (

--- a/src/components/RawJsonDisplay.tsx
+++ b/src/components/RawJsonDisplay.tsx
@@ -8,7 +8,7 @@ interface RawJsonDisplayProps {
 
 const RawJsonDisplay: FC<RawJsonDisplayProps> = ({ data }) => {
   return (
-    <div className="max-w-md p-4 text-sm bg-white rounded-lg shadow-md">
+    <div className="overflow-auto text-xs border border-gray-300 h-96">
       <SyntaxHighlighter language="json" style={atomOneLight}>
         {/* <pre className="text-sm text-left whitespace-pre-wrap">
         

--- a/src/components/SchemaPropertyInput.tsx
+++ b/src/components/SchemaPropertyInput.tsx
@@ -14,9 +14,11 @@ const SchemaPropertyInput: React.FC<{
   className?: string;
   isSubProperty?: true;
 }> = ({ index, property, onChange, className, isSubProperty }) => {
-  const [subProperties, setSubProperties] = useState<SchemaPropertyWithTitle[]>(
-    property.items ? Object.values(property.items) : [],
-  );
+  // const [subProperties, setSubProperties] = useState<SchemaPropertyWithTitle[]>(
+  //   property.items ? Object.values(property.items) : [],
+  // );
+
+  const subProperties = property.items ? Object.values(property.items) : [];
 
   const handlePropertyChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
@@ -35,7 +37,7 @@ const SchemaPropertyInput: React.FC<{
   ) => {
     const updatedSubProperties = [...subProperties];
     updatedSubProperties[subIndex] = subProperty;
-    setSubProperties(updatedSubProperties);
+    // setSubProperties(updatedSubProperties);
     onChange(index, {
       ...property,
       items: { ...property.items, [subProperty.title]: subProperty },
@@ -53,7 +55,7 @@ const SchemaPropertyInput: React.FC<{
         type: 'string',
         example: '',
       };
-      setSubProperties(updatedSubProperties);
+      // setSubProperties(updatedSubProperties);
       onChange(index, {
         ...property,
         items: {
@@ -156,7 +158,7 @@ const SchemaPropertyInput: React.FC<{
                 <SchemaPropertyInput
                   index={index}
                   property={item}
-                  onChange={() => handleSubPropertyChange(index, item)}
+                  onChange={handleSubPropertyChange}
                   isSubProperty
                 />
               </li>

--- a/src/components/SchemaPropertyInput.tsx
+++ b/src/components/SchemaPropertyInput.tsx
@@ -18,14 +18,6 @@ const SchemaPropertyInput: React.FC<{
     property.items ? Object.values(property.items) : [],
   );
 
-  // const handlePropertyChange = (
-  //   event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
-  // ) => {
-  //   const { name, value } = event.target;
-
-  //   onChange(index, { ...property, [name]: value });
-  // };
-
   const handlePropertyChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
   ) => {
@@ -110,24 +102,26 @@ const SchemaPropertyInput: React.FC<{
           </select>
         </div>
 
-        <div>
-          <label
-            htmlFor={`example-${index}`}
-            className={styles.formControlLabel}
-          >
-            Example
-          </label>
+        {property.type !== 'array' && (
+          <div>
+            <label
+              htmlFor={`example-${index}`}
+              className={styles.formControlLabel}
+            >
+              Example
+            </label>
 
-          <input
-            type="text"
-            name="example"
-            id={`example-${index}`}
-            value={property.example?.toString() || ''}
-            onChange={handlePropertyChange}
-            className={styles.formControl}
-            placeholder="e.g. 81464-B"
-          />
-        </div>
+            <input
+              type="text"
+              name="example"
+              id={`example-${index}`}
+              value={property.example?.toString() || ''}
+              onChange={handlePropertyChange}
+              className={styles.formControl}
+              placeholder="e.g. 81464-B"
+            />
+          </div>
+        )}
       </div>
 
       <div>
@@ -162,7 +156,7 @@ const SchemaPropertyInput: React.FC<{
                 <SchemaPropertyInput
                   index={index}
                   property={item}
-                  onChange={() => handleSubPropertyChange(index, property)}
+                  onChange={() => handleSubPropertyChange(index, item)}
                   isSubProperty
                 />
               </li>

--- a/src/context/schema-context.ts
+++ b/src/context/schema-context.ts
@@ -1,0 +1,22 @@
+import { StatefulSchemaPropertyWithTitle } from '@Components/SchemaPropertyInput';
+import { createContext } from 'react';
+
+type SchemaContextType = {
+  schemaProperties: StatefulSchemaPropertyWithTitle[];
+  handleAddSchemaProperty: (parentIndex?: number) => void;
+  handleRemoveSchemaProperty: (index: number, parentIndex?: number) => void;
+  handleSchemaPropertyChange: (
+    index: number,
+    property: StatefulSchemaPropertyWithTitle,
+    parentIndex?: number,
+  ) => void;
+};
+
+const SchemaContext = createContext<SchemaContextType>({
+  schemaProperties: [],
+  handleAddSchemaProperty: () => undefined,
+  handleRemoveSchemaProperty: () => undefined,
+  handleSchemaPropertyChange: () => undefined,
+});
+
+export default SchemaContext;

--- a/src/types/schemaTypes.ts
+++ b/src/types/schemaTypes.ts
@@ -5,4 +5,11 @@ export type SchemaProperty = {
   example?: string | number | boolean | object | Array<any>;
 };
 
+export type StatefulSchemaProperty = {
+  description: string;
+  type: 'string' | 'array' | 'object' | 'number' | 'boolean';
+  items?: SchemaProperty[];
+  example?: string | number | boolean | object | Array<any>;
+};
+
 export type Schema = Record<string, SchemaProperty>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "baseUrl": "./src/",
     "paths": {
       "@Components/*": ["components/*"],
+      "@Context/*": ["context/*"],
       "@Styles/*": ["styles/*"],
       "@Types/*": ["types/*"],
       "@Utils/*": ["utils/*"]


### PR DESCRIPTION
## Description
Made several large-ish changes. Added a context and updated some types.

- Created context to work with instead of trying to pass state management between components.
- Created a new `StatefulSchemaProperty` where the items are an array. Still preserved `SchemaProperty` where the items are still a `Record`
- Minor UI changes.
- Fixed issue with nested items not updating

## Testing

- [ ] Pull down branch and run `npm install && npm run dev`
- [ ] Add a new field, ensure you can remove it
- [ ] Update a field to make sure the state is updating
- [ ] Change a field to a type of array, and repeat steps 1-3 with array items
- [ ] Test generating data from an uploaded PDF

## Notes

- When using an array the results seem relatively accurate, but they array items are returning description, type and example. I'm not sure if that's an error on my side or the API